### PR TITLE
Fix bug in Windows testing

### DIFF
--- a/test/test_ReadData.jl
+++ b/test/test_ReadData.jl
@@ -48,3 +48,6 @@ end
 if isdir("assets/WorldClim")
     rm("assets/WorldClim", recursive = true)
 end
+if isdir("assets/EarthEnv")
+    rm("assets/EarthEnv", recursive = true)
+end


### PR DESCRIPTION
ReadOnlyMemoryError() that only seems to occur on windows.