### PR TITLE
Use p7zip_jll instead of ZipArchives

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,7 +39,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
-ZipArchives = "49080126-0e18-4c2a-b176-c102e4b3760c"
+p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [weakdeps]
 DataPipeline = "9ced6f0a-eb77-43a8-bbd1-bbf3031b0d12"
@@ -95,7 +95,7 @@ StatsBase = "0.32.2, 0.33, 0.34"
 Test = "1.9"
 UUIDs = "1.9"
 Unitful = "1.7"
-ZipArchives = "2"
+p7zip_jll = "17"
 julia = "1.9"
 
 [extras]

--- a/ext/EcoSISTEMDataPipelineExt.jl
+++ b/ext/EcoSISTEMDataPipelineExt.jl
@@ -1,24 +1,13 @@
 module EcoSISTEMDataPipelineExt
 
 using EcoSISTEM
-using ZipArchives
+import p7zip_jll
 
 @info "Creating data pipeline interface for EcoSISTEM..."
 
 function EcoSISTEM.unziptemp(path::String)
-    zr = ZipReader(read(open(path)))
     newpath = mktempdir()
-    files = zip_names(zr)
-    for file in files
-        if zip_isdir(zr, file)
-            mkdir(joinpath(newpath, file))
-        end
-    end
-    for file in files
-        if !zip_isdir(zr, file)
-            write(joinpath(newpath, file), zip_readentry(zr, file, String))
-        end
-    end
+    run(`$(p7zip_jll.p7zip()) x -tzip -y -o$(newpath) $(path)`)
     @debug "Unzipped to $newpath"
     return newpath
 end


### PR DESCRIPTION
ZipArchives doesn't currently have a safe way to unzip into a temporary directory.

The `write(joinpath(newpath, file), zip_readentry(zr, file, String))` code you are using is very dangerous.

This could allow a bad zip file with a file name of for example "/home/bob/.ssh/bad_secret_key" to overwrite any file in your file system. p7zip_jll has many additional checks to try and prevent this.

If you want to use ZipArchives safely you need to make sure the file names are what you expect them to be before writing any files.