### PR TITLE
Dimension-order mismatch bug

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -4,7 +4,7 @@
     "applicationCategory": "ecology",
     "codeRepository": "https://github.com/EcoJulia/EcoSISTEM.jl",
     "dateCreated": "2016-11-29",
-    "dateModified": "2026-07-25",
+    "dateModified": "2026-07-26",
     "datePublished": "2021-04-20",
     "description": "Package for running dynamic ecosystem simulations in Julia",
     "downloadUrl": "https://github.com/EcoJulia/EcoSISTEM.jl/archive/refs/tags/v0.5.0.tar.gz",

--- a/src/Generate.jl
+++ b/src/Generate.jl
@@ -82,7 +82,7 @@ function update!(eco::Ecosystem, timestep::Unitful.Time)
     dims = _countsubcommunities(eco.habitat.regime)
     nspp = size(eco.abundances.grid, 1)
     params = eco.spplist.params
-    width = getdimension(eco)[1]
+    height = getdimension(eco)[1]
 
     # Set the overall resource supply of that square
     update_resource_usage!(eco)
@@ -104,9 +104,9 @@ function update!(eco::Ecosystem, timestep::Unitful.Time)
         # Loop through grid squares
         for i in 1:dims
             # Convert 1D dimension to 2D coordinates
-            (x, y) = convert_coords(eco, i, width)
+            (y, x) = convert_coords(eco, i, height)
             # Check if grid cell currently active
-            (eco.habitat.active[x, y] && (eco.cache.totalE[i, 1] > 0)) ||
+            (eco.habitat.active[y, x] && (eco.cache.totalE[i, 1] > 0)) ||
                 continue
             for j in jstart:jend
                 rng = getrng(eco, j)
@@ -238,9 +238,9 @@ end
 function _resource_adjustment(eco::AbstractEcosystem, supply::AbstractSupply,
                               i::Int64, sp::Int64)
     params = eco.spplist.params
-    width = getdimension(eco)[1]
-    (x, y) = convert_coords(eco, i, width)
-    K = getsupply(eco)[x, y] * eco.spplist.demand.exchange_rate
+    height = getdimension(eco)[1]
+    (y, x) = convert_coords(eco, i, height)
+    K = getsupply(eco)[y, x] * eco.spplist.demand.exchange_rate
     # Get resource supplies of species in square
     ϵ̄ = eco.spplist.demand.resource[sp] *
         eco.spplist.demand.exchange_rate
@@ -263,12 +263,12 @@ function _resource_adjustment(eco::AbstractEcosystem,
                               supply::SupplyCollection2,
                               i::Int64,
                               sp::Int64)
-    width = getdimension(eco)[1]
-    (x, y) = convert_coords(eco, i, width)
+    height = getdimension(eco)[1]
+    (y, x) = convert_coords(eco, i, height)
     params = eco.spplist.params
-    K1 = _getsupply(eco.habitat.supply.one)[x, y] *
+    K1 = _getsupply(eco.habitat.supply.one)[y, x] *
          eco.spplist.demand.one.exchange_rate
-    K2 = _getsupply(eco.habitat.supply.two)[x, y] *
+    K2 = _getsupply(eco.habitat.supply.two)[y, x] *
          eco.spplist.demand.two.exchange_rate
     # Get abundances of square we are interested in
     # Get resource supplies of species in square
@@ -291,58 +291,58 @@ function _resource_adjustment(eco::AbstractEcosystem,
 end
 
 """
-    convert_coords(eco, i::Int64, width::Int64)
-    convert_coords(eco, x::Int64, y::Int64, width::Int64)
-Convert coordinates from two-dimensional (`x`,`y`) format to one dimension
-(`i`), or vice versa, using the `width` of the grid. This function can also be
-applied to arrays of coordinates.
+    convert_coords(eco, i::Int64, height::Int64)
+    convert_coords(eco, y::Int64, x::Int64, height::Int64)
+Convert coordinates from two-dimensional (`y`,`x`) format to one dimension
+(`i`), or vice versa, using the `height` (dimension 1) of the grid. This
+function can also be applied to arrays of coordinates.
 """
 function convert_coords(eco::AbstractEcosystem,
                         i::Int64,
-                        width::Int64 = getdimension(eco)[1])
-    x = ((i - 1) % width) + 1
-    y = div((i - 1), width) + 1
-    return (x, y)
+                        height::Int64 = getdimension(eco)[1])
+    y = ((i - 1) % height) + 1
+    x = div((i - 1), height) + 1
+    return (y, x)
 end
 function convert_coords(eco::AbstractEcosystem,
                         pos::Tuple{Int64, Int64},
-                        width::Int64 = getdimension(eco)[1])
-    i = pos[1] + width * (pos[2] - 1)
+                        height::Int64 = getdimension(eco)[1])
+    i = pos[1] + height * (pos[2] - 1)
     return i
 end
 
-function convert_coords(i::Int64, width::Int64)
-    x = ((i - 1) % width) + 1
-    y = div((i - 1), width) + 1
-    return (x, y)
+function convert_coords(i::Int64, height::Int64)
+    y = ((i - 1) % height) + 1
+    x = div((i - 1), height) + 1
+    return (y, x)
 end
-function convert_coords(x::Int64, y::Int64, width::Int64)
-    i = x + width * (y - 1)
+function convert_coords(y::Int64, x::Int64, height::Int64)
+    i = y + height * (x - 1)
     return i
 end
 """
-    calc_lookup_moves!(bound, x::Int64, y::Int64, sp::Int64, eco::Ecosystem, abun::Int64)
+    calc_lookup_moves!(bound, y::Int64, x::Int64, sp::Int64, eco::Ecosystem, abun::Int64)
 
 Calculate the number of moves taken by a species, `sp`, from a specific grid
-square location (`x`, `y`). There is a boundary condition, `bound`, which
+square location (`y`, `x`). There is a boundary condition, `bound`, which
 determines how the species can move across space (see AbstractBoundary). The
 total abundance of individuals is given in `abun`, which may be the number of
 births in the timestep, or total individuals.
 """
 function calc_lookup_moves!(bound::NoBoundary,
-                            x::Int64,
                             y::Int64,
+                            x::Int64,
                             sp::Int64,
                             eco::AbstractEcosystem,
                             abun::Int64)
     lookup = getlookup(eco, sp)
-    maxX = getdimension(eco)[1] - x
-    maxY = getdimension(eco)[2] - y
+    maxY = getdimension(eco)[1] - y
+    maxX = getdimension(eco)[2] - x
     # Can't go over maximum dimension
-    for i in eachindex(lookup.x)
-        valid = (-x < lookup.x[i] <= maxX) &&
-                (-y < lookup.y[i] <= maxY) &&
-                (eco.habitat.active[lookup.x[i] + x, lookup.y[i] + y])
+    for i in eachindex(lookup.y)
+        valid = (-y < lookup.y[i] <= maxY) &&
+                (-x < lookup.x[i] <= maxX) &&
+                (eco.habitat.active[lookup.y[i] + y, lookup.x[i] + x])
 
         lookup.pnew[i] = valid ? lookup.p[i] : 0.0
     end
@@ -352,21 +352,21 @@ function calc_lookup_moves!(bound::NoBoundary,
 end
 
 function calc_lookup_moves!(bound::Cylinder,
-                            x::Int64,
                             y::Int64,
+                            x::Int64,
                             sp::Int64,
                             eco::AbstractEcosystem,
                             abun::Int64)
     lookup = getlookup(eco, sp)
-    maxX = getdimension(eco)[1] - x
-    maxY = getdimension(eco)[2] - y
+    maxY = getdimension(eco)[1] - y
+    maxX = getdimension(eco)[2] - x
     # Can't go over maximum dimension
-    for i in eachindex(lookup.x)
+    for i in eachindex(lookup.y)
         newx = -x < lookup.x[i] <= maxX ? lookup.x[i] + x :
-               mod(lookup.x[i] + x - 1, getdimension(eco)[1]) + 1
+               mod(lookup.x[i] + x - 1, getdimension(eco)[2]) + 1
 
         valid = (-y < lookup.y[i] <= maxY) &&
-                (eco.habitat.active[newx, lookup.y[i] + y])
+                (eco.habitat.active[lookup.y[i] + y, newx])
 
         lookup.pnew[i] = valid ? lookup.p[i] : 0.0
     end
@@ -376,21 +376,21 @@ function calc_lookup_moves!(bound::Cylinder,
 end
 
 function calc_lookup_moves!(bound::Torus,
-                            x::Int64,
                             y::Int64,
+                            x::Int64,
                             sp::Int64,
                             eco::AbstractEcosystem,
                             abun::Int64)
     lookup = getlookup(eco, sp)
-    maxX = getdimension(eco)[1] - x
-    maxY = getdimension(eco)[2] - y
+    maxY = getdimension(eco)[1] - y
+    maxX = getdimension(eco)[2] - x
     # Can't go over maximum dimension
-    for i in eachindex(lookup.x)
-        newx = -x < lookup.x[i] <= maxX ? lookup.x[i] + x :
-               mod(lookup.x[i] + x - 1, getdimension(eco)[1]) + 1
+    for i in eachindex(lookup.y)
         newy = -y < lookup.y[i] <= maxY ? lookup.y[i] + y :
-               mod(lookup.y[i] + y - 1, getdimension(eco)[2]) + 1
-        valid = eco.habitat.active[newx, newy]
+               mod(lookup.y[i] + y - 1, getdimension(eco)[1]) + 1
+        newx = -x < lookup.x[i] <= maxX ? lookup.x[i] + x :
+               mod(lookup.x[i] + x - 1, getdimension(eco)[2]) + 1
+        valid = eco.habitat.active[newy, newx]
 
         lookup.pnew[i] = valid ? lookup.p[i] : 0.0
     end
@@ -445,18 +445,18 @@ function _move!(eco::AbstractEcosystem,
                 sp::Int64,
                 grd::Matrix{Int64},
                 amount::Int64)
-    width, height = getdimension(eco)
-    (x, y) = convert_coords(eco, i, width)
+    height, width = getdimension(eco)
+    (y, x) = convert_coords(eco, i, height)
     lookup = getlookup(eco, sp)
-    calc_lookup_moves!(getboundary(eco.spplist.movement), x, y, sp, eco, amount)
+    calc_lookup_moves!(getboundary(eco.spplist.movement), y, x, sp, eco, amount)
     # Lose moves from current grid square
     grd[sp, i] -= amount
     # Map moves to location in grid
     moves = lookup.moves
-    for j in eachindex(lookup.x)
-        newx = mod(lookup.x[j] + x - 1, width) + 1
+    for j in eachindex(lookup.y)
         newy = mod(lookup.y[j] + y - 1, height) + 1
-        loc = convert_coords(eco, (newx, newy), width)
+        newx = mod(lookup.x[j] + x - 1, width) + 1
+        loc = convert_coords(eco, (newy, newx), height)
         grd[sp, loc] += moves[j]
     end
     return eco

--- a/src/Habitats.jl
+++ b/src/Habitats.jl
@@ -29,11 +29,13 @@ xmin(regime::AbstractRegime) = 0
 ymin(regime::AbstractRegime) = 0
 xcellsize(regime::AbstractRegime) = Float64(regime.size / km)
 ycellsize(regime::AbstractRegime) = Float64(regime.size / km)
-xcells(regime::AbstractRegime) = size(regime.matrix, 1)
-ycells(regime::AbstractRegime) = size(regime.matrix, 2)
+# dimension 1 of `regime.matrix` is y (rows), dimension 2 is x (columns) —
+# matching the grid convention used throughout `Generate.jl`.
+xcells(regime::AbstractRegime) = size(regime.matrix, 2)
+ycells(regime::AbstractRegime) = size(regime.matrix, 1)
 function indices(regime::AbstractRegime)
     return hcat(collect.(convert_coords.(eachindex(regime.matrix),
-                                         xcells(regime)))...)'
+                                         ycells(regime)))...)'
 end
 indices(regime::AbstractRegime, idx) = indices(regime)[:, idx]
 coordinates(regime::AbstractRegime) = indices(regime)
@@ -129,9 +131,9 @@ function _getdimension(regime::Union{DiscreteRegime, ContinuousRegime,
 end
 function _getsize(regime::Union{DiscreteRegime, ContinuousRegime,
                                 ContinuousTimeRegime})
-    x = regime.size * size(regime.matrix, 1)
-    y = regime.size * size(regime.matrix, 2)
-    return x * y
+    ysize = regime.size * size(regime.matrix, 1)
+    xsize = regime.size * size(regime.matrix, 2)
+    return ysize * xsize
 end
 import Base.size
 function Base.size(regime::Union{DiscreteRegime, ContinuousRegime,
@@ -203,7 +205,7 @@ function _resettime!(regime::RegimeCollection3)
 end
 
 function _getdimension(regime::Union{RegimeCollection2, RegimeCollection3})
-    return (size(regime.one.matrix, 1), size(regime.two.matrix, 2))
+    return (size(regime.one.matrix, 1), size(regime.one.matrix, 2))
 end
 function _getsize(regime::Union{RegimeCollection2, RegimeCollection3})
     return _getsize(regime.one)
@@ -223,8 +225,8 @@ Return the regime value at 1D grid position `pos`, converting to 2D coordinates
 internally.
 """
 function getregime(regime::H, pos::Int64) where {H <: AbstractRegime}
-    x, y = convert_coords(pos, size(regime.matrix, 1))
-    return regime.matrix[x, y]
+    y, x = convert_coords(pos, size(regime.matrix, 1))
+    return regime.matrix[y, x]
 end
 @doc (@doc getregime) getregime(::H, ::Symbol) where {H <: AbstractRegime}
 function getregime(regime::H, field::Symbol) where {H <: AbstractRegime}
@@ -237,8 +239,8 @@ Return the regime value at position `pos` for the current time slice of a
 [`ContinuousTimeRegime`](@ref).
 """
 function getregime(regime::ContinuousTimeRegime, pos::Int64)
-    x, y = convert_coords(pos, size(regime.matrix, 1))
-    return regime.matrix[x, y, regime.time]
+    y, x = convert_coords(pos, size(regime.matrix, 1))
+    return regime.matrix[y, x, regime.time]
 end
 
 function Diversity.API._countsubcommunities(regime::RegimeCollection2)

--- a/src/MPIGenerate.jl
+++ b/src/MPIGenerate.jl
@@ -59,9 +59,9 @@ function EcoSISTEM.update!(eco::MPIEcosystem, timestep::Unitful.Time)
         # Loop through grid squares
         for sc in 1:numsc
             # Convert 1D dimension to 2D coordinates
-            (x, y) = EcoSISTEM.convert_coords(eco, sc)
+            (y, x) = EcoSISTEM.convert_coords(eco, sc)
             # Check if grid cell currently active
-            (eco.habitat.active[x, y] && (eco.cache.totalE[sc, 1] > 0)) ||
+            (eco.habitat.active[y, x] && (eco.cache.totalE[sc, 1] > 0)) ||
                 continue
             for mpisp in mpistart:mpiend
                 truesp = eco.firstsp + mpisp - 1
@@ -233,20 +233,20 @@ function EcoSISTEM.move!(eco::MPIEcosystem,
                          truesp::Int64,
                          grd::Matrix{Int64},
                          births::Int64)
-    width, height = getdimension(eco)
-    (x, y) = EcoSISTEM.convert_coords(eco, sc, width)
+    height, width = getdimension(eco)
+    (y, x) = EcoSISTEM.convert_coords(eco, sc, height)
     lookup = EcoSISTEM.getlookup(eco, truesp)
-    calc_lookup_moves!(getboundary(eco.spplist.movement), x, y, truesp, eco,
+    calc_lookup_moves!(getboundary(eco.spplist.movement), y, x, truesp, eco,
                        births)
     # Lose moves from current grid square
     mpisp = truesp - eco.firstsp + 1
     grd[mpisp, sc] -= births
     # Map moves to location in grid
     moves = lookup.moves
-    for i in eachindex(lookup.x)
-        newx = mod(lookup.x[i] + x - 1, width) + 1
+    for i in eachindex(lookup.y)
         newy = mod(lookup.y[i] + y - 1, height) + 1
-        loc = EcoSISTEM.convert_coords(eco, (newx, newy), width)
+        newx = mod(lookup.x[i] + x - 1, width) + 1
+        loc = EcoSISTEM.convert_coords(eco, (newy, newx), height)
         grd[mpisp, loc] += moves[i]
     end
     return eco

--- a/src/Simplify.jl
+++ b/src/Simplify.jl
@@ -64,8 +64,11 @@ end
 # ---------------------------------------------------------------------------
 
 # Turn a physical grid extent (x, y lengths) and a cell `size` into an integer
-# `(nx, ny)` cell count, warning if the extent is not close to a whole number of
-# cells. Returns both the cell counts and the total area for the `*AE` builders.
+# `(ny, nx)` cell count — dimension 1 = y, dimension 2 = x, matching the grid
+# convention used throughout `Generate.jl`/`Habitats.jl` (and the data-driven
+# `build_environment` path) — warning if the extent is not close to a whole
+# number of cells. Returns both the cell counts and the total area for the
+# `*AE` builders.
 function _extent_dims(extent::Tuple{<:Unitful.Length, <:Unitful.Length},
                       size::Unitful.Length)
     rx = uconvert(NoUnits, extent[1] / size)
@@ -75,7 +78,7 @@ function _extent_dims(extent::Tuple{<:Unitful.Length, <:Unitful.Length},
     (nx ≥ 1 && ny ≥ 1 && isapprox(rx, nx; rtol = 1.0e-2) &&
      isapprox(ry, ny; rtol = 1.0e-2)) ||
         @warn "Grid extent $(extent[1]) × $(extent[2]) is not close to a whole number of $size cells; using a $nx × $ny grid."
-    return (Int64(nx), Int64(ny)), float(extent[1] * extent[2])
+    return (Int64(ny), Int64(nx)), float(extent[1] * extent[2])
 end
 
 # `_canonical(value, axis)` (axis-driven, in `src/Layer.jl`) canonicalises a regime value to its axis's
@@ -684,4 +687,3 @@ function build_environment(regimes::Tuple{Vararg{Union{ClimateRaster, Tuple,
     act = _resolve_active(active, regime, tlat, tlong)
     return GridHabitat{typeof(regime), typeof(supply)}(regime, act, supply)
 end
-

--- a/test/test_Generate.jl
+++ b/test/test_Generate.jl
@@ -85,6 +85,75 @@ end
           (0.0, 0.0)
 end
 
+@testset "non-square grid: y/x dimension order regression" begin
+    # A square grid cannot detect an X/Y mixup (sizes and indices coincide by
+    # accident). This grid is deliberately asymmetric, so confused code either
+    # throws a BoundsError (indexing a 2-row array with a column-range value up
+    # to 6) or silently reads the wrong cells.
+    N = 4
+    ny, nx = 2, 6
+    grid = (ny, nx)
+    area = 100.0km^2
+
+    # A partial active mask — only column x=1 is active, every row — to check
+    # the active-mask indexing itself corresponds to (y, x), not (x, y):
+    # deliberately asymmetric (not a full row/column/diagonal) so a swap would
+    # show up as reading the wrong cells, not coincidentally the same ones.
+    partial_active = fill(false, ny, nx)
+    partial_active[:, 1] .= true
+    partial_habitat = simplehabitat(274.0K, grid, 10000.0kJ / km^2 / day, area,
+                                    partial_active)
+    @test size(partial_habitat.regime.matrix) == grid
+    @test size(partial_habitat.active) == grid
+    @test all(partial_habitat.active[y, 1] for y in 1:ny)
+    @test all(!partial_habitat.active[y, x] for y in 1:ny, x in 2:nx)
+
+    tolerance = NicheTolerance(Temperature, Normal, fill(274.0K, N),
+                               fill(0.5K, N))
+    param = EqualPop(0.6 / month, 0.6 / month, 1.0, 0.0, 1000.0)
+    kernel = GaussianKernel.(fill(1.0km, N), 1.0e-3)
+    movement = BirthOnlyMovement(kernel)
+    native = fill(true, N)
+    abun = fill(10, N)
+    resource = SolarDemand(fill(2.0kJ / day, N))
+    sppl = SpeciesList(N, tolerance, abun, resource, movement, param, native)
+
+    # A fully-active habitat for exercising calc_lookup_moves!/update! at
+    # extreme y/x coordinates — every cell reachable, so no cell's move
+    # probabilities can go to zero regardless of dimension order.
+    habitat = simplehabitat(274.0K, grid, 10000.0kJ / km^2 / day, area)
+    @test size(habitat.regime.matrix) == grid
+    @test size(habitat.active) == grid
+
+    nichefit = NicheSuitability{eltype(habitat.regime)}()
+    eco = Ecosystem(sppl, habitat, nichefit)
+
+    # getdimension must report (ny, nx) — the actual array shape — not (nx, ny).
+    @test EcoSISTEM.getdimension(eco) == grid
+
+    # Calling calc_lookup_moves! at every combination of extreme y/x coordinates
+    # must not throw — a BoundsError here is exactly what an X/Y mixup produces
+    # on a non-square grid (e.g. checking a y=2-valid offset against nx=6's
+    # bound instead of ny=2's, then indexing a nonexistent row of `active`).
+    for (y, x) in ((1, 1), (ny, 1), (1, nx), (ny, nx))
+        @test_nowarn EcoSISTEM.calc_lookup_moves!(eco.spplist.movement.boundary,
+                                                  y, x, 1, eco, 5)
+        @test_nowarn EcoSISTEM.calc_lookup_moves!(Cylinder(), y, x, 1, eco, 5)
+        @test_nowarn EcoSISTEM.calc_lookup_moves!(Torus(), y, x, 1, eco, 5)
+    end
+
+    # convert_coords must round-trip correctly through the (y,x) convention —
+    # height (dimension 1) is ny, not nx.
+    for i in 1:(ny * nx)
+        (y, x) = EcoSISTEM.convert_coords(eco, i, ny)
+        @test 1 <= y <= ny && 1 <= x <= nx
+        @test EcoSISTEM.convert_coords(y, x, ny) == i
+    end
+
+    # A full timestep must run without error on this asymmetric grid.
+    @test_nowarn update!(eco, 1month)
+end
+
 @testset "Multithreaded reproducibility" begin
     # A seeded run must give identical results regardless of the number of
     # threads. Run the same seeded simulation in child processes forced to use

--- a/test/test_Habitats.jl
+++ b/test/test_Habitats.jl
@@ -27,8 +27,9 @@ using RasterDataSources
     @test EcoSISTEM.ymin(habitat.regime) == 0
     @test EcoSISTEM.xcellsize(habitat.regime) == sqrt(area / prod(grid)) / km
     @test EcoSISTEM.ycellsize(habitat.regime) == sqrt(area / prod(grid)) / km
-    @test EcoSISTEM.xcells(habitat.regime) == size(habitat.regime, 1)
-    @test EcoSISTEM.ycells(habitat.regime) == size(habitat.regime, 2)
+    # dimension 1 of regime.matrix is y (rows), dimension 2 is x (columns)
+    @test EcoSISTEM.xcells(habitat.regime) == size(habitat.regime, 2)
+    @test EcoSISTEM.ycells(habitat.regime) == size(habitat.regime, 1)
     @test EcoSISTEM.indices(habitat.regime) ==
           EcoSISTEM.coordinates(habitat.regime)
     @test EcoSISTEM.indices(habitat.regime, 1) ==

--- a/test/test_Simplify.jl
+++ b/test/test_Simplify.jl
@@ -61,6 +61,17 @@ end
         # extent not a whole number of cells warns
         @test_logs (:warn,) match_mode=:any build_environment((5km, 5km), 2km,
                                                               298.0K)
+
+        # A square extent can't distinguish x from y (both dimensions have the
+        # same count), which is exactly why a historical X/Y mixup between this
+        # synthetic path and the data-driven build_environment path went
+        # undetected. `extent` is documented as (x, y); with a non-square
+        # extent the resulting matrix must be (ny, nx) — dimension 1 = y —
+        # matching the convention used throughout Generate.jl/Habitats.jl, not
+        # (nx, ny).
+        nonsquare = build_environment((12km, 4km), cellsize, 298.0K)
+        @test size(nonsquare.regime.matrix) == (4, 12)
+        @test size(nonsquare.active) == (4, 12)
     end
 
     @testset "dispatch on the regime argument type" begin


### PR DESCRIPTION
Fixed a dimension-order mismatch (y, x) in new Raster code vs (x, y) in old species abundance. Now (y, x) everywhere.